### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   db:
     image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql-native-password=ON
     volumes:
       - ./db:/var/lib/mysql:cached          # database in `/var/lib/mysql` will be synced with your local folder `./db`
     environment:


### PR DESCRIPTION
fix initialization command for mysql

see: 
https://stackoverflow.com/questions/78445419/unknown-variable-default-authentication-plugin-mysql-native-password

So for your docker-compose.yml, change the line from

    command: ["mysqld", "--default-authentication-plugin=mysql_native_password"]

to

    command: ["mysqld", "--mysql-native-password=ON"]
